### PR TITLE
Typos and spelling fixes to help file

### DIFF
--- a/doc/vim-ai.txt
+++ b/doc/vim-ai.txt
@@ -10,7 +10,7 @@ translate, etc.
 
 COMMANDS                                        *vim-ai-commands*
 
-To set-up key bindings and expamples see:
+To set-up key bindings and examples see:
 https://github.com/madox2/vim-ai
 
                                                 *:AI*
@@ -31,7 +31,7 @@ Options: >
   \  },
   \}
 
-Check OpenAI docs for more infomration:
+Check OpenAI docs for more information:
 https://platform.openai.com/docs/api-reference/completions
 
                                                 *:AIEdit*
@@ -51,7 +51,7 @@ Options: >
   \  },
   \}
 
-Check OpenAI docs for more infomration:
+Check OpenAI docs for more information:
 https://platform.openai.com/docs/api-reference/completions
 
                                                 *:AIChat*
@@ -84,7 +84,7 @@ Options: >
   \  },
   \}
 
-Check OpenAI docs for more infomration:
+Check OpenAI docs for more information:
 https://platform.openai.com/docs/api-reference/chat
 
                                                 *:AIRedo*
@@ -122,7 +122,7 @@ You can also customize the options in the chat header: >
 
 KEY BINDINGS
 
-Examples how configure key bindins and customize commands: >
+Examples how configure key bindings and customize commands: >
 
   " complete text on the current line or in visual selection
   nnoremap <leader>a :AI<CR>


### PR DESCRIPTION
Love the plugin.  I just noticed the few spelling errors/typos in the help reading it, so this is only a very minor tidy up.

It may also be worth noting in the readme or help that the vim build has to have a python3 installation of the same point version. I got briefly stumped by `has("python3")` returning 0 when `:version` returned +python3/dyn, but it turned out the Vim version was two points ahead (3.11 v 3.9) of what I had installed.  