### PR TITLE
Support including OpenAI Org ID in the request to OpenAI API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,14 @@ You only share and pay for what you specifically select, for prompts and chat co
 # save api key to `~/.config/openai.token` file
 echo "YOUR_OPENAI_API_KEY" > ~/.config/openai.token
 
+# or save api key and org id to `~/.config/openai.token` file
+#echo "YOUR_OPENAI_API_KEY,YOUR_OPENAI_ORG_ID" > ~/.config/openai.token
+
 # alternatively set it as an environment variable
 export OPENAI_API_KEY="YOUR_OPENAI_API_KEY"
+
+# or set with org id
+#export OPENAI_API_KEY="YOUR_OPENAI_API_KEY,YOUR_OPENAI_ORG_ID"
 ```
 
 ### Using `vim-plug`

--- a/py/utils.py
+++ b/py/utils.py
@@ -16,15 +16,26 @@ debug_log_file = vim.eval("g:vim_ai_debug_log_file")
 
 def load_api_key():
     config_file_path = os.path.join(os.path.expanduser("~"), ".config/openai.token")
-    api_key = os.getenv("OPENAI_API_KEY")
+    api_key_param_value = os.getenv("OPENAI_API_KEY")
     try:
         with open(config_file_path, 'r') as file:
-            api_key = file.read()
+            api_key_param_value = file.read()
     except Exception:
         pass
-    if not api_key:
+
+    if not api_key_param_value:
         raise Exception("Missing OpenAI API key")
-    return api_key.strip()
+
+    # The text is in format of "<api key>,<org id>" and the
+    # <org id> part is optional
+    elements = api_key_param_value.strip().split(",")
+    api_key = elements[0].strip()
+    org_id = None
+
+    if len(elements) > 1:
+        org_id = elements[1].strip()
+
+    return (api_key, org_id)
 
 def normalize_config(config):
     normalized = { **config }
@@ -119,13 +130,17 @@ def printDebug(text, *args):
 
 OPENAI_RESP_DATA_PREFIX = 'data: '
 OPENAI_RESP_DONE = '[DONE]'
-OPENAI_API_KEY = load_api_key()
+(OPENAI_API_KEY, OPENAI_ORG_ID) = load_api_key()
 
 def openai_request(url, data, options):
     headers = {
         "Content-Type": "application/json",
         "Authorization": f"Bearer {OPENAI_API_KEY}"
     }
+
+    if OPENAI_ORG_ID is not None:
+        headers["OpenAI-Organization"] =  f"{OPENAI_ORG_ID}"
+
     request_timeout=options['request_timeout']
     req = urllib.request.Request(
         url,


### PR DESCRIPTION
## Context

The `vim-ai` doesn't support including the HTTP header `OpenAI-Organization` in the request so the API usage from `vim-ai` is counted toward the default selected organization in the OpenAI account setting. When the OpenAI account is in multiple organizations, I have to change the default org before using `vim-ai` in order to put the API usage to the desired org

## Changes

The token config from `~/.config/openai.token` or shell env `OPENAI_API_KEY` is a comma-delimited array with 02 elements in maximum: api key and org id.