### PR TITLE
feat(chat): add `include` role to include files

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,22 @@ You are a Clean Code expert, I have the following code, please refactor it in a 
 
 ```
 
-Supported chat roles are **`>>> system`**, **`>>> user`** and **`<<< assistant`**
+To include files in the chat a special `include` role is used:
+
+```
+>>> user
+
+Generate documentation for the following files
+
+>>> include
+
+/home/user/myproject/requirements.txt
+/home/user/myproject/**/*.py
+```
+
+Each file's contents will be added to an additional `user` role message with the files separated by `==> {path} <==`, where path is the path to the file. Globbing is expanded out via `glob.gob` and relative paths to the current working directory (as determined by `getcwd()`) will be resolved to absolute paths.
+
+Supported chat roles are **`>>> system`**, **`>>> user`**, **`>>> include`** and **`<<< assistant`**
 
 ### `:AINewChat`
 

--- a/doc/tags
+++ b/doc/tags
@@ -7,4 +7,5 @@ vim-ai	vim-ai.txt	/*vim-ai*
 vim-ai-about	vim-ai.txt	/*vim-ai-about*
 vim-ai-commands	vim-ai.txt	/*vim-ai-commands*
 vim-ai-config	vim-ai.txt	/*vim-ai-config*
+vim-ai-include	vim-ai.txt	/*vim-ai-include*
 vim-ai.txt	vim-ai.txt	/*vim-ai.txt*

--- a/doc/vim-ai.txt
+++ b/doc/vim-ai.txt
@@ -104,6 +104,25 @@ Options: >
 Check OpenAI docs for more information:
 https://platform.openai.com/docs/api-reference/chat
 
+INCLUDE FILES                                  *vim-ai-include*
+
+To include files in the chat a special `include` role is used: >
+
+  >>> user
+
+  Generate documentation for the following files
+
+  >>> include
+
+  /home/user/myproject/requirements.txt
+  /home/user/myproject/**/*.py
+
+Each file's contents will be added to an additional `user` role message with
+the files separated by `==> {path} <==`, where path is the path to the file.
+Globbing is expanded out via `glob.gob` and relative paths to the current
+working directory (as determined by `getcwd()`) will be resolved to absolute
+paths.
+
                                                 *:AINewChat*
 
 :AINewChat {preset shortname}?      spawn a new conversation with a given open

--- a/syntax/aichat.vim
+++ b/syntax/aichat.vim
@@ -1,5 +1,6 @@
 syntax match aichatRole ">>> system"
 syntax match aichatRole ">>> user"
+syntax match aichatRole ">>> include"
 syntax match aichatRole "<<< assistant"
 
 highlight default link aichatRole Comment


### PR DESCRIPTION
Files may be included in the chat by a special `include` role. Each file's contents will be added to an additional `user` role message with the files separated by `==> {path} <==` where `{path}` is the path to the file. Globbing is expanded out via `glob.glob` and relative apths to the current working directory (as determined by `getcwd()`) will be resolved to absolute paths.

Example:

```
>>> user

Generate documentation for the following files

>>> include

/home/user/myproject/src/../requirements.txt
/home/user/myproject/**/*.py

```

Fixes: #69