### PR TITLE
Fix instructions which lead to `Undefined variable: g:vim_ai_chat` if config options are not initially set

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ let g:vim_ai_chat = {
 \}
 ```
 
-Or modify options directly during the vim session:
+Once the above is set, you can modify options directly during the vim session:
 
 ```vim
 let g:vim_ai_chat['options']['model'] = 'gpt-4'


### PR DESCRIPTION
Fix instructions which lead to `Undefined variable: g:vim_ai_chat` if config options are not initially set