### PR TITLE
add switch to use roles defined *.aichat files

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,17 +321,22 @@ let g:vim_ai_chat = {
 
 ### Roles
 
-Roles are configured in `vimfiles/vim_ai/roles.yaml` (where `vimfiles` is `~/.vim` on Linux or `%USERPROFILE%/vimfiles` on Microsoft Windows) which uses the following syntax:
+Roles are defined
 
-```
-- name: refactorer
-  prompt: >
-    You are a Clean Code expert, I have the following code, please refactor it in
-    a more clean and concise way so that my colleagues can maintain the code more
-    easily. Also, explain why you want to refactor the code so that I can add the
-    explanation to the Pull Request.
-  temperature: 0.2
-```
+- either in `vimfiles/vim_ai/roles/*.aichat` files using the above syntax
+- or in the single file `vimfiles/vim_ai/roles.yaml` using the following [aichat](https://github.com/sigoden/aichat/wiki/Role-Examples) syntax
+
+    ```
+    - name: refactorer
+      prompt: >
+        You are a clean-code expert.
+        Please refactor the input and explain why.
+      temperature: 0.2
+    ```
+
+
+Here `vimfiles` is `~/.vim` on Unix or `%USERPROFILE%/vimfiles` on Microsoft
+Windows) 
 
 ### Using custom API
 

--- a/README.md
+++ b/README.md
@@ -65,25 +65,19 @@ git clone https://github.com/madox2/vim-ai.git ~/.local/share/nvim/site/pack/plu
 To use an AI command, type the command followed by an instruction prompt. You can also combine it with a visual selection. Here is a brief overview of available commands:
 
 ```
-=============== Basic AI commands ===============
+========== Basic AI commands ========
 
 :AI         complete text
 :AIEdit     edit text
 :AIChat     continue or open new chat
-
-=============== Role AI commands ================
-
-:AIAs {role}      complete text as {role}
-:AIEditAs {role}  edit text as {role}
-:AIChatAs {role}  continue or open new chat as {role}
-
-=================== Utilities ===================
 
 :AIRedo     repeat last AI command
 :AINewChat  open new chat
 
 :help vim-ai
 ```
+
+**Tip:** A role {role} can be passed to the above commands by an initial parameter /{role}, for example `:AIEdit /refactorer`. 
 
 **Tip:** Press `Ctrl-c` anytime to cancel completion
 
@@ -323,6 +317,20 @@ let g:vim_ai_chat = {
 " - setting max tokens to 0 will exclude it from the OpenAI API request parameters, it is
 "   unclear/undocumented what it exactly does, but it seems to resolve issues when the model
 "   hits token limit, which respond with `OpenAI: HTTPError 400`
+```
+
+### Roles
+
+Roles are configured in `vimfiles/vim_ai/roles.yaml` (where `vimfiles` is `~/.vim` on Linux or `%USERPROFILE%/vimfiles` on Microsoft Windows) which uses the following syntax:
+
+```
+- name: refactorer
+  prompt: >
+    You are a Clean Code expert, I have the following code, please refactor it in
+    a more clean and concise way so that my colleagues can maintain the code more
+    easily. Also, explain why you want to refactor the code so that I can add the
+    explanation to the Pull Request.
+  temperature: 0.2
 ```
 
 ### Using custom API

--- a/README.md
+++ b/README.md
@@ -65,13 +65,19 @@ git clone https://github.com/madox2/vim-ai.git ~/.local/share/nvim/site/pack/plu
 To use an AI command, type the command followed by an instruction prompt. You can also combine it with a visual selection. Here is a brief overview of available commands:
 
 ```
-========= Basic AI commands =========
+=============== Basic AI commands ===============
 
 :AI         complete text
 :AIEdit     edit text
 :AIChat     continue or open new chat
 
-============= Utilities =============
+=============== Role AI commands ================
+
+:AIAs {role}      complete text as {role}
+:AIEditAs {role}  edit text as {role}
+:AIChatAs {role}  continue or open new chat as {role}
+
+=================== Utilities ===================
 
 :AIRedo     repeat last AI command
 :AINewChat  open new chat

--- a/autoload/vim_ai.vim
+++ b/autoload/vim_ai.vim
@@ -124,9 +124,9 @@ endfunction
 " - a:1          - optional instruction prompt
 " - a:2          - optional selection pending (to override g:vim_ai_is_selection_pending)
 function! vim_ai#AIRun(config, ...) range abort
-  let l:config = vim_ai_config#ExtendDeep(deepcopy(g:vim_ai_complete), a:config)
-
+  let l:config = a:config
   let l:instruction = a:0 > 0 ? trim(a:1) : ''
+
   if l:instruction =~# '^/'
     let i = match(l:instruction . ' ', '\s')
     let role = l:instruction[1:i-1]
@@ -134,16 +134,19 @@ function! vim_ai#AIRun(config, ...) range abort
     let l:config = vim_ai_roles#set_config_role(l:config, role)
   endif
 
+  let s:last_config = deepcopy(l:config)
+
+  let l:config = vim_ai_config#ExtendDeep(deepcopy(g:vim_ai_complete), l:config)
+
   " used for getting in Python script
   let l:is_selection = a:0 > 1 ? a:2 : g:vim_ai_is_selection_pending
   let l:selection = s:GetSelectionOrRange(l:is_selection, a:firstline, a:lastline)
 
   let l:prompt = s:MakePrompt(l:config, l:instruction, l:selection)
 
-  let s:last_command = 'complete'
-  let s:last_config = a:config
   let s:last_instruction = l:instruction
   let s:last_is_selection = l:is_selection
+  let s:last_command = 'complete'
   let s:last_firstline = a:firstline
   let s:last_lastline = a:lastline
 
@@ -164,9 +167,9 @@ endfunction
 " - a:1          - optional instruction prompt
 " - a:2          - optional selection pending (to override g:vim_ai_is_selection_pending)
 function! vim_ai#AIEditRun(config, ...) range abort
-  let l:config = vim_ai_config#ExtendDeep(deepcopy(g:vim_ai_edit), a:config)
-
+  let l:config = a:config
   let l:instruction = a:0 > 0 ? trim(a:1) : ''
+
   if l:instruction =~# '^/'
     let i = match(l:instruction . ' ', '\s')
     let role = l:instruction[1:i-1]
@@ -174,16 +177,19 @@ function! vim_ai#AIEditRun(config, ...) range abort
     let l:config = vim_ai_roles#set_config_role(l:config, role)
   endif
 
+  let s:last_config = deepcopy(l:config)
+
+  let l:config = vim_ai_config#ExtendDeep(deepcopy(g:vim_ai_edit), l:config)
+
   " used for getting in Python script
   let l:is_selection = a:0 > 1 ? a:2 : g:vim_ai_is_selection_pending
   let l:selection = s:GetSelectionOrRange(l:is_selection, a:firstline, a:lastline)
 
   let l:prompt = s:MakePrompt(l:config, l:instruction, l:selection)
 
-  let s:last_command = 'edit'
-  let s:last_config = a:config
   let s:last_instruction = l:instruction
   let s:last_is_selection = l:is_selection
+  let s:last_command = 'edit'
   let s:last_firstline = a:firstline
   let s:last_lastline = a:lastline
 
@@ -199,8 +205,6 @@ endfunction
 " - config       - function scoped vim_ai_chat config
 " - a:1          - optional instruction prompt
 function! vim_ai#AIChatRun(uses_range, config, ...) range abort
-  let l:config = vim_ai_config#ExtendDeep(deepcopy(g:vim_ai_chat), a:config)
-
   " l:is_selection used in Python script
   if a:uses_range
     let l:is_selection = g:vim_ai_is_selection_pending
@@ -210,23 +214,30 @@ function! vim_ai#AIChatRun(uses_range, config, ...) range abort
     let l:selection = ''
   endif
 
-  if a:0 > 0 || a:uses_range
-    let l:instruction = a:0 > 0 ? trim(a:1) : ''
+  let l:config = a:config
+
+  if a:0 > 0
+    let l:instruction = trim(a:1)
     if l:instruction =~# '^/'
       let i = match(l:instruction . ' ', '\s')
       let role = l:instruction[1:i-1]
       let l:instruction = l:instruction[i:-1]
       let l:config = vim_ai_roles#set_config_role(l:config, role)
     endif
-
-    let l:prompt = s:MakePrompt(l:config, l:instruction, l:selection)
   else
     let l:instruction = ""
+  endif
+
+  let s:last_config = deepcopy(l:config)
+  let l:config = vim_ai_config#ExtendDeep(deepcopy(g:vim_ai_chat), l:config)
+
+  if a:0 > 0 || a:uses_range
+    let l:prompt = s:MakePrompt(l:config, l:instruction, l:selection)
+  else
     let l:prompt = ""
   endif
 
   let s:last_command = 'chat'
-  let s:last_config = a:config
 
   call s:set_paste(l:config)
   if &filetype != 'aichat'

--- a/autoload/vim_ai.vim
+++ b/autoload/vim_ai.vim
@@ -124,14 +124,14 @@ endfunction
 " - a:1          - optional instruction prompt
 " - a:2          - optional selection pending (to override g:vim_ai_is_selection_pending)
 function! vim_ai#AIRun(config, ...) range abort
-  let l:config = vim_ai_config#ExtendDeep(g:vim_ai_complete, a:config)
+  let l:config = vim_ai_config#ExtendDeep(deepcopy(g:vim_ai_complete), a:config)
 
   let l:instruction = a:0 > 0 ? trim(a:1) : ''
   if l:instruction =~# '^/'
     let i = match(l:instruction . ' ', '\s')
     let role = l:instruction[1:i-1]
     let l:instruction = l:instruction[i:-1]
-    call vim_ai_roles#set_config_role(l:config, role)
+    let l:config = vim_ai_roles#set_config_role(l:config, role)
   endif
 
   " used for getting in Python script
@@ -164,14 +164,14 @@ endfunction
 " - a:1          - optional instruction prompt
 " - a:2          - optional selection pending (to override g:vim_ai_is_selection_pending)
 function! vim_ai#AIEditRun(config, ...) range abort
-  let l:config = vim_ai_config#ExtendDeep(g:vim_ai_edit, a:config)
+  let l:config = vim_ai_config#ExtendDeep(deepcopy(g:vim_ai_edit), a:config)
 
   let l:instruction = a:0 > 0 ? trim(a:1) : ''
   if l:instruction =~# '^/'
     let i = match(l:instruction . ' ', '\s')
     let role = l:instruction[1:i-1]
     let l:instruction = l:instruction[i:-1]
-    call vim_ai_roles#set_config_role(l:config, role)
+    let l:config = vim_ai_roles#set_config_role(l:config, role)
   endif
 
   " used for getting in Python script
@@ -199,7 +199,7 @@ endfunction
 " - config       - function scoped vim_ai_chat config
 " - a:1          - optional instruction prompt
 function! vim_ai#AIChatRun(uses_range, config, ...) range abort
-  let l:config = vim_ai_config#ExtendDeep(g:vim_ai_chat, a:config)
+  let l:config = vim_ai_config#ExtendDeep(deepcopy(g:vim_ai_chat), a:config)
 
   " l:is_selection used in Python script
   if a:uses_range
@@ -216,7 +216,7 @@ function! vim_ai#AIChatRun(uses_range, config, ...) range abort
       let i = match(l:instruction . ' ', '\s')
       let role = l:instruction[1:i-1]
       let l:instruction = l:instruction[i:-1]
-      call vim_ai_roles#set_config_role(l:config, role)
+      let l:config = vim_ai_roles#set_config_role(l:config, role)
     endif
 
     let l:prompt = s:MakePrompt(l:config, l:instruction, l:selection)

--- a/autoload/vim_ai_config.vim
+++ b/autoload/vim_ai_config.vim
@@ -93,6 +93,25 @@ call s:MakeConfig("vim_ai_chat")
 call s:MakeConfig("vim_ai_complete")
 call s:MakeConfig("vim_ai_edit")
 
+if !exists('g:vim_ai_roles_path')
+  let s:vimfiles_dir = split(&runtimepath, ',')[0]
+  if isdirectory(s:vimfiles_dir)
+    let g:vimfiles_dir = s:vimfiles_dir
+  elseif has('unix')
+    let g:vimfiles_dir = expand('$HOME') . '/.vim'
+  else " if has('win32')
+    " see :help vimfiles
+    let g:vimfiles_dir = expand('$HOME') . '\vimfiles'
+  endif
+  let g:vim_ai_roles_path = s:vimfiles_dir . '/vim_ai/roles.yaml'
+  unlet s:vimfiles_dir
+endif
+
+" " Only warn once roles are used completing or calling *Ascommands
+" if !filereadable(g:vim_ai_roles_path)
+"   echoerr 'Error: g:vim_ai_roles_path = ' g:vim_ai_roles_path . 'not readable!'
+" endif
+
 function! vim_ai_config#load()
   " nothing to do - triggers autoloading of this file
 endfunction

--- a/autoload/vim_ai_config.vim
+++ b/autoload/vim_ai_config.vim
@@ -103,14 +103,17 @@ if !exists('g:vim_ai_roles_path')
     " see :help vimfiles
     let g:vimfiles_dir = expand('$HOME') . '\vimfiles'
   endif
-  let g:vim_ai_roles_path = s:vimfiles_dir . '/vim_ai/roles.yaml'
+
+  if isdirectory(s:vimfiles_dir . '/vim_ai/roles')
+    let g:vim_ai_roles_path = s:vimfiles_dir . '/vim_ai/roles'
+  elseif filereadable(s:vimfiles_dir . '/vim_ai/roles.yaml')
+    let g:vim_ai_roles_path = s:vimfiles_dir . '/vim_ai/roles.yaml'
+  else
+    echomsg 'g:vim_ai_roles_path was not set'
+  endif
+
   unlet s:vimfiles_dir
 endif
-
-" " Only warn once roles are used completing or calling *Ascommands
-" if !filereadable(g:vim_ai_roles_path)
-"   echoerr 'Error: g:vim_ai_roles_path = ' g:vim_ai_roles_path . 'not readable!'
-" endif
 
 function! vim_ai_config#load()
   " nothing to do - triggers autoloading of this file

--- a/autoload/vim_ai_roles.vim
+++ b/autoload/vim_ai_roles.vim
@@ -1,10 +1,70 @@
 function! vim_ai_roles#get_roles() abort
-  if !filereadable(g:vim_ai_roles_path)
-    echoerr 'Error: cannot read file g:vim_ai_roles_path = ' . g:vim_ai_roles_path . '!'
-    return
+  if isdirectory(g:vim_ai_roles_path)
+    return vim_ai_roles#get_roles_folder(g:vim_ai_roles_path)
+  elseif filereadable(g:vim_ai_roles_path)
+    return vim_ai_roles#get_roles_file(g:vim_ai_roles_path)
+  else
+    throw 'g:vim_ai_roles_path = ' . g:vim_ai_roles_path . ' must be a valid path'
+  endif
+endfunction
+
+function! vim_ai_roles#get_roles_folder(folder) abort
+  if !isdirectory(a:folder)
+    throw 'cannot read folder ' . a:folder
   endif
 
-  let lines = readfile(g:vim_ai_roles_path)
+  let file_dictionary = {}
+  for file in split(glob(a:folder . '/*.aichat'), '\n')
+    let file_name = fnamemodify(file, ':t:r')
+    let file_dictionary[file_name] = s:ParseChatHeaderOptions(file)
+  endfor
+  return file_dictionary
+endfunction
+
+function! s:ParseChatHeaderOptions(filepath)
+  let lines = readfile(a:filepath)
+  try
+    let options = {}
+    let contains_chat_options = index(lines, '[chat-options]') != -1
+    if contains_chat_options
+      let options_index = index(lines, '[chat-options]')
+      let i = options_index + 1
+      while i < len(lines)
+        let line = lines[i]
+        if line =~ '^\s*#'
+          " Ignore comments
+          let i += 1
+          continue
+        endif
+        if line == ''
+          " Stop at the end of the region
+          break
+        endif
+        let parts = split(line, '=')
+        if len(parts) == 2
+          let key = parts[0]
+          let value = parts[1]
+          if key == 'initial_prompt'
+            let key = 'prompt'
+            let value = split(value, '\\n')
+          endif
+          let options[key] = value
+        endif
+        let i += 1
+      endwhile
+    endif
+    return options
+  catch
+    throw "Invalid [chat-options] in file " . a:filepath
+  endtry
+endfunction
+
+function! vim_ai_roles#get_roles_file(file) abort
+  if !filereadable(a:file)
+    throw 'cannot read file ' . a:file
+  endif
+
+  let lines = readfile(a:file)
   let roles = {}
   let current_role = ''
   let current_attribute = ''
@@ -28,12 +88,8 @@ function! vim_ai_roles#get_roles() abort
 endfunction
 
 function! vim_ai_roles#completion(A,L,P) abort
-  if !filereadable(g:vim_ai_roles_path)
-    echoerr 'Error: cannot read file g:vim_ai_roles_path = ' . g:vim_ai_roles_path . '!'
-    return ''
-  endif
   let roles = keys(vim_ai_roles#get_roles())
-  call map(roles, "'/' . v:val")
+  call map(roles, '"/" . v:val')
   return filter(roles, 'v:val =~ "^' . a:A . '"')
 endfunction
 
@@ -46,6 +102,9 @@ function! vim_ai_roles#set_config_role(config, role) abort
     if !has_key(roles[a:role], 'prompt')
       throw "The role " . a:role . " does not have a prompt!"
     endif
+  catch
+    " Handle the exception here, e.g., by displaying an error message
+    echohl ErrorMsg | echomsg v:exception | echohl None
   endtry
   let a:config.options.initial_prompt =
         \ ">>> system\n" . roles[a:role].prompt

--- a/autoload/vim_ai_roles.vim
+++ b/autoload/vim_ai_roles.vim
@@ -1,0 +1,79 @@
+function! vim_ai_roles#get_roles() abort
+  if !filereadable(g:vim_ai_roles_path)
+    echoerr 'Error: cannot read file g:vim_ai_roles_path = ' . g:vim_ai_roles_path . '!'
+    return
+  endif
+
+  let lines = readfile(g:vim_ai_roles_path)
+  let roles = {}
+  let current_role = ''
+  let current_attribute = ''
+
+  for line in lines
+    if line =~ '^-\s*name:\s*'
+      let current_role = matchstr(line, '^-\s*name:\s*\zs.*')->trim()
+      let roles[current_role] = {}
+    elseif line =~ '^\s\+\S\+:\s*[^>|]'
+      let current_attribute = matchstr(line, '^\s\+\zs[^:[:space:]]\+\ze:\s*[^>|]')->trim()
+      let roles[current_role][current_attribute] = matchstr(line, '^\s*' . current_attribute . ':\zs.*')->trim()
+    elseif line =~ '^\s\+\S\+:\s*[>|]'
+      let current_attribute = matchstr(line, '^\s\+\zs\S\+\ze:\s*[>|]')->trim()
+      let roles[current_role][current_attribute] = ''
+    else
+      let roles[current_role][current_attribute] .= line->trim() . "\n"
+    endif
+  endfor
+
+  return roles
+endfunction
+
+function! vim_ai_roles#completion(A,L,P) abort
+  if !filereadable(g:vim_ai_roles_path)
+    echoerr 'Error: cannot read file g:vim_ai_roles_path = ' . g:vim_ai_roles_path . '!'
+    return ''
+  endif
+  return filter(keys(vim_ai_roles#get_roles()), 'v:val =~ "^' . a:A . '"')
+endfunction
+
+function! vim_ai_roles#get_config(role) abort
+  let roles = vim_ai_roles#get_roles()
+  if !has_key(roles, a:role)
+    echoerr "Specified role does not exist!"
+    return
+  endif
+  if !has_key(roles[a:role], 'prompt')
+    echoerr "Specified role does not have a prompt!"
+    return
+  endif
+  let config = { "options": { "initial_prompt":
+        \ ">>> system\n" . roles[a:role].prompt, },}
+  if has_key(roles[a:role], 'temperature')
+    let config.temperature = roles[a:role].temperature
+  endif
+
+  return config
+endfunction
+
+function! vim_ai_roles#AIRunAs(qargs) range abort
+  let i = match(trim(a:qargs) . ' ', '\s')
+  let role = a:qargs[0:i-1]
+  let l:prompt = a:qargs[i:-1]
+  let l:config = vim_ai_roles#get_config(role)
+  exe a:firstline.",".a:lastline . "call vim_ai#AIRun(l:config, l:prompt)"
+endfunction
+
+function! vim_ai_roles#AIEditRunAs(qargs) range abort
+  let i = match(trim(a:qargs) . ' ', '\s')
+  let role = a:qargs[0:i-1]
+  let l:prompt = a:qargs[i:-1]
+  let l:config = vim_ai_roles#get_config(role)
+  exe a:firstline.",".a:lastline . "call vim_ai#AIEditRun(l:config, l:prompt)"
+endfunction
+
+function! vim_ai_roles#AIChatRunAs(uses_range, qargs) range abort
+  let i = match(trim(a:qargs) . ' ', '\s')
+  let role = a:qargs[0:i-1]
+  let l:prompt = a:qargs[i:-1]
+  let l:config = vim_ai_roles#get_config(role)
+  exe a:firstline.",".a:lastline . "call vim_ai#AIChatRun(a:uses_range, l:config, l:prompt)"
+endfunction

--- a/autoload/vim_ai_roles.vim
+++ b/autoload/vim_ai_roles.vim
@@ -111,4 +111,5 @@ function! vim_ai_roles#set_config_role(config, role) abort
   if has_key(roles[a:role], 'temperature')
     let a:config.temperature = roles[a:role].temperature
   endif
+  return vim_ai_config#ExtendDeep(deepcopy(a:config), roles[a:role])
 endfunction

--- a/autoload/vim_ai_roles.vim
+++ b/autoload/vim_ai_roles.vim
@@ -32,48 +32,24 @@ function! vim_ai_roles#completion(A,L,P) abort
     echoerr 'Error: cannot read file g:vim_ai_roles_path = ' . g:vim_ai_roles_path . '!'
     return ''
   endif
-  return filter(keys(vim_ai_roles#get_roles()), 'v:val =~ "^' . a:A . '"')
+  let roles = keys(vim_ai_roles#get_roles())
+  call map(roles, "'/' . v:val")
+  return filter(roles, 'v:val =~ "^' . a:A . '"')
 endfunction
 
-function! vim_ai_roles#get_config(role) abort
+function! vim_ai_roles#set_config_role(config, role) abort
   let roles = vim_ai_roles#get_roles()
-  if !has_key(roles, a:role)
-    echoerr "Specified role does not exist!"
-    return
-  endif
-  if !has_key(roles[a:role], 'prompt')
-    echoerr "Specified role does not have a prompt!"
-    return
-  endif
-  let config = { "options": { "initial_prompt":
-        \ ">>> system\n" . roles[a:role].prompt, },}
+  try
+    if !has_key(roles, a:role)
+      throw "The role " . a:role . " does not exist!"
+    endif
+    if !has_key(roles[a:role], 'prompt')
+      throw "The role " . a:role . " does not have a prompt!"
+    endif
+  endtry
+  let a:config.options.initial_prompt =
+        \ ">>> system\n" . roles[a:role].prompt
   if has_key(roles[a:role], 'temperature')
-    let config.temperature = roles[a:role].temperature
+    let a:config.temperature = roles[a:role].temperature
   endif
-
-  return config
-endfunction
-
-function! vim_ai_roles#AIRunAs(qargs) range abort
-  let i = match(trim(a:qargs) . ' ', '\s')
-  let role = a:qargs[0:i-1]
-  let l:prompt = a:qargs[i:-1]
-  let l:config = vim_ai_roles#get_config(role)
-  exe a:firstline.",".a:lastline . "call vim_ai#AIRun(l:config, l:prompt)"
-endfunction
-
-function! vim_ai_roles#AIEditRunAs(qargs) range abort
-  let i = match(trim(a:qargs) . ' ', '\s')
-  let role = a:qargs[0:i-1]
-  let l:prompt = a:qargs[i:-1]
-  let l:config = vim_ai_roles#get_config(role)
-  exe a:firstline.",".a:lastline . "call vim_ai#AIEditRun(l:config, l:prompt)"
-endfunction
-
-function! vim_ai_roles#AIChatRunAs(uses_range, qargs) range abort
-  let i = match(trim(a:qargs) . ' ', '\s')
-  let role = a:qargs[0:i-1]
-  let l:prompt = a:qargs[i:-1]
-  let l:config = vim_ai_roles#get_config(role)
-  exe a:firstline.",".a:lastline . "call vim_ai#AIChatRun(a:uses_range, l:config, l:prompt)"
 endfunction

--- a/doc/tags
+++ b/doc/tags
@@ -8,4 +8,5 @@ vim-ai-about	vim-ai.txt	/*vim-ai-about*
 vim-ai-commands	vim-ai.txt	/*vim-ai-commands*
 vim-ai-config	vim-ai.txt	/*vim-ai-config*
 vim-ai-include	vim-ai.txt	/*vim-ai-include*
+vim-ai-roles	vim-ai.txt	/*vim-ai-roles*
 vim-ai.txt	vim-ai.txt	/*vim-ai.txt*

--- a/doc/vim-ai.txt
+++ b/doc/vim-ai.txt
@@ -106,6 +106,9 @@ https://platform.openai.com/docs/api-reference/chat
 
 ROLES                                        *vim-ai-roles*
 
+A role {role} can be passed to the above commands by an initial parameter
+/{role}, for example :AIEdit /refactorer.
+
 Roles are configured in 'vimfiles'/vim_ai/roles.yaml (where 'vimfiles' is ~/.vim on
 Linux or %USERPROFILE%/vimfiles on Microsoft Windows) which uses the following
 syntax:
@@ -118,25 +121,6 @@ syntax:
     easily. Also, explain why you want to refactor the code so that I can add the
     explanation to the Pull Request.
   temperature: 0.2
-
-                                                *:AIAs*
-
-:AIAs {role}                           complete the text on the current line
-:AIAs {role} {prompt}                  complete the prompt
-<selection> :AIAs {role}               complete the selection
-<selection> :AIAs {role} {instruction} complete the selection using the instruction
-
-                                                *:AIEditAs*
-
-<selection>? :AIEditAs {role}                edit the current line or the selection
-<selection>? :AIEditAs {role} {instruction}  edit the current line or the
-                                             selection using the instruction
-
-                                                *:AIChatAs*
-
-:AIChat {role}                              continue or start a new conversation.
-<selection>? :AIChat {role} {instruction}?  start a new conversation given the
-                                            selection, the instruction or both
 
 
 INCLUDE FILES                                  *vim-ai-include*

--- a/doc/vim-ai.txt
+++ b/doc/vim-ai.txt
@@ -104,6 +104,41 @@ Options: >
 Check OpenAI docs for more information:
 https://platform.openai.com/docs/api-reference/chat
 
+ROLES                                        *vim-ai-roles*
+
+Roles are configured in 'vimfiles'/vim_ai/roles.yaml (where 'vimfiles' is ~/.vim on
+Linux or %USERPROFILE%/vimfiles on Microsoft Windows) which uses the following
+syntax:
+
+>
+- name: refactorer
+  prompt: >
+    You are a Clean Code expert, I have the following code, please refactor it in
+    a more clean and concise way so that my colleagues can maintain the code more
+    easily. Also, explain why you want to refactor the code so that I can add the
+    explanation to the Pull Request.
+  temperature: 0.2
+
+                                                *:AIAs*
+
+:AIAs {role}                           complete the text on the current line
+:AIAs {role} {prompt}                  complete the prompt
+<selection> :AIAs {role}               complete the selection
+<selection> :AIAs {role} {instruction} complete the selection using the instruction
+
+                                                *:AIEditAs*
+
+<selection>? :AIEditAs {role}                edit the current line or the selection
+<selection>? :AIEditAs {role} {instruction}  edit the current line or the
+                                             selection using the instruction
+
+                                                *:AIChatAs*
+
+:AIChat {role}                              continue or start a new conversation.
+<selection>? :AIChat {role} {instruction}?  start a new conversation given the
+                                            selection, the instruction or both
+
+
 INCLUDE FILES                                  *vim-ai-include*
 
 To include files in the chat a special `include` role is used: >

--- a/doc/vim-ai.txt
+++ b/doc/vim-ai.txt
@@ -109,17 +109,19 @@ ROLES                                        *vim-ai-roles*
 A role {role} can be passed to the above commands by an initial parameter
 /{role}, for example :AIEdit /refactorer.
 
-Roles are configured in 'vimfiles'/vim_ai/roles.yaml (where 'vimfiles' is ~/.vim on
-Linux or %USERPROFILE%/vimfiles on Microsoft Windows) which uses the following
-syntax:
+Roles are defined
+
+  - either in 'vimfiles'/vim_ai/roles/*.aichat files
+  - or in the single file 'vimfiles'/vim_ai/roles.yaml
+
+Here 'vimfiles' is ~/.vim on Linux or %USERPROFILE%/vimfiles on Microsoft
+Windows) which uses the following aichat syntax:
 
 >
 - name: refactorer
   prompt: >
-    You are a Clean Code expert, I have the following code, please refactor it in
-    a more clean and concise way so that my colleagues can maintain the code more
-    easily. Also, explain why you want to refactor the code so that I can add the
-    explanation to the Pull Request.
+    You are a clean-code expert.
+    Please refactor the input and explain why.
   temperature: 0.2
 
 

--- a/plugin/vim-ai.vim
+++ b/plugin/vim-ai.vim
@@ -18,5 +18,10 @@ command! -range   -nargs=? AIEdit    <line1>,<line2>call vim_ai#AIEditRun({}, <q
 " AIChat defaults to passing nothing which is achieved by -range=0 and passing
 " <count> as described at https://stackoverflow.com/a/20133772
 command! -range=0 -nargs=? AIChat    <line1>,<line2>call vim_ai#AIChatRun(<count>, {}, <q-args>)
+
 command! -nargs=?          AINewChat                call vim_ai#AINewChatRun(<q-args>)
 command!                   AIRedo                   call vim_ai#AIRedoRun()
+
+command! -range   -nargs=+ -complete=customlist,vim_ai_roles#completion AIAs <line1>,<line2>call vim_ai_roles#AIRunAs(<q-args>)
+command! -range   -nargs=+ -complete=customlist,vim_ai_roles#completion AIEditAs <line1>,<line2>call vim_ai_roles#AIEditAs(<q-args>)
+command! -range=0 -nargs=+ -complete=customlist,vim_ai_roles#completion AIChatAs <line1>,<line2>call vim_ai_roles#AIChatRunAs(<count>, <q-args>)

--- a/plugin/vim-ai.vim
+++ b/plugin/vim-ai.vim
@@ -12,16 +12,12 @@ augroup vim_ai
           \ let g:vim_ai_is_selection_pending = mode() =~# "^[vV\<C-v>]"
 augroup END
 
-command! -range   -nargs=? AI        <line1>,<line2>call vim_ai#AIRun({}, <q-args>)
-command! -range   -nargs=? AIEdit    <line1>,<line2>call vim_ai#AIEditRun({}, <q-args>)
+command! -range   -nargs=? -complete=customlist,vim_ai_roles#completion AI        <line1>,<line2>call vim_ai#AIRun({}, <q-args>)
+command! -range   -nargs=? -complete=customlist,vim_ai_roles#completion AIEdit    <line1>,<line2>call vim_ai#AIEditRun({}, <q-args>)
 " Whereas AI and AIEdit default to passing the current line as range
 " AIChat defaults to passing nothing which is achieved by -range=0 and passing
 " <count> as described at https://stackoverflow.com/a/20133772
-command! -range=0 -nargs=? AIChat    <line1>,<line2>call vim_ai#AIChatRun(<count>, {}, <q-args>)
+command! -range=0 -nargs=? -complete=customlist,vim_ai_roles#completion AIChat    <line1>,<line2>call vim_ai#AIChatRun(<count>, {}, <q-args>)
 
 command! -nargs=?          AINewChat                call vim_ai#AINewChatRun(<q-args>)
 command!                   AIRedo                   call vim_ai#AIRedoRun()
-
-command! -range   -nargs=+ -complete=customlist,vim_ai_roles#completion AIAs <line1>,<line2>call vim_ai_roles#AIRunAs(<q-args>)
-command! -range   -nargs=+ -complete=customlist,vim_ai_roles#completion AIEditAs <line1>,<line2>call vim_ai_roles#AIEditAs(<q-args>)
-command! -range=0 -nargs=+ -complete=customlist,vim_ai_roles#completion AIChatAs <line1>,<line2>call vim_ai_roles#AIChatRunAs(<count>, <q-args>)


### PR DESCRIPTION
[The wiki](https://github.com/madox2/vim-ai?tab=readme-ov-file#custom-commands) suggests defining a custom command for every role, but more convenient would be listing them inside a text file (using the simple aichat format for compatibility) which are then loaded inside a dictionary.