### PR TITLE
feat: add an option to customize api key file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ echo "YOUR_OPENAI_API_KEY,YOUR_OPENAI_ORG_ID" > ~/.config/openai.token
 export OPENAI_API_KEY="YOUR_OPENAI_API_KEY,YOUR_OPENAI_ORG_ID"
 ```
 
+The default api key file location is `~/.config/openai.token`, but you can change it by setting the `g:vim_ai_token_file_path` in your `.vimrc` file:
+
+```vim
+let g:vim_ai_token_file_path = '~/.config/openai.token'
+```
+
 ### Using `vim-plug`
 
 ```vim

--- a/autoload/vim_ai_config.vim
+++ b/autoload/vim_ai_config.vim
@@ -70,6 +70,9 @@ endif
 if !exists("g:vim_ai_debug_log_file")
   let g:vim_ai_debug_log_file = "/tmp/vim_ai_debug.log"
 endif
+if !exists("g:vim_ai_token_file_path")
+  let g:vim_ai_token_file_path = "~/.config/openai.token"
+endif
 
 function! vim_ai_config#ExtendDeep(defaults, override) abort
   let l:result = a:defaults

--- a/py/utils.py
+++ b/py/utils.py
@@ -19,7 +19,8 @@ class KnownError(Exception):
     pass
 
 def load_api_key():
-    config_file_path = os.path.join(os.path.expanduser("~"), ".config/openai.token")
+    config_file_path = os.path.expanduser(vim.eval("g:vim_ai_token_file_path"))
+    print(config_file_path)
     api_key_param_value = os.getenv("OPENAI_API_KEY")
     try:
         with open(config_file_path, 'r') as file:


### PR DESCRIPTION
I use multiple LLM services, their endpoint URLs and API tokens are different. I want to switch the LLM backend server when I use
`vim-ai` plugin. So I add an option `g:vim_ai_token_file_path` to change my API key file conveniently.