### PR TITLE
offer markdown highlighting in aichat files

### DIFF
--- a/doc/vim-ai.txt
+++ b/doc/vim-ai.txt
@@ -161,6 +161,10 @@ You can also customize the options in the chat header: >
   generate a paragraph of lorem ipsum
   ...
 
+MARKDOWN HIGHLIGHTING                            *g:aichat_markdown*
+
+Set g:aichat_markdown = 1 to enable full markdown highlighting in aichat files
+
 KEY BINDINGS
 
 Examples how configure key bindings and customize commands: >

--- a/syntax/aichat.vim
+++ b/syntax/aichat.vim
@@ -6,14 +6,14 @@ if get(g:, 'aichat_markdown', 0) == 1
   runtime! syntax/markdown.vim
 endif
 
-syntax region myRegion start=/>>>.*$\zs/ end=/\ze<<<.*$/
-highlight default link myRegion Normal
-
 syntax match aichatRole ">>> system"
 syntax match aichatRole ">>> user"
 syntax match aichatRole ">>> include"
 syntax match aichatRole "<<< assistant"
 
 highlight default link aichatRole Comment
+
+syntax region userInput start=/^>>>\s/ end=/^<<<\s/ contains=aichatRole
+highlight link userInput NONE
 
 let b:current_syntax = 'aichat'

--- a/syntax/aichat.vim
+++ b/syntax/aichat.vim
@@ -1,6 +1,16 @@
+if exists("b:current_syntax")
+  finish
+endif
+
+if get(g:, 'aichat_markdown', 0) == 1
+  runtime! syntax/markdown.vim
+endif
+
 syntax match aichatRole ">>> system"
 syntax match aichatRole ">>> user"
 syntax match aichatRole ">>> include"
 syntax match aichatRole "<<< assistant"
 
 highlight default link aichatRole Comment
+
+let b:current_syntax = 'aichat'

--- a/syntax/aichat.vim
+++ b/syntax/aichat.vim
@@ -6,6 +6,9 @@ if get(g:, 'aichat_markdown', 0) == 1
   runtime! syntax/markdown.vim
 endif
 
+syntax region myRegion start=/>>>.*$\zs/ end=/\ze<<<.*$/
+highlight default link myRegion Normal
+
 syntax match aichatRole ">>> system"
 syntax match aichatRole ">>> user"
 syntax match aichatRole ">>> include"


### PR DESCRIPTION
Markdown highlighting within aichat files is controlled by a global variable `g:aichat_markdown`.

The Vim documentation and the syntax file for aichat have been updated. Markdown highlighting is disabled by default when editing .aichat files, but can be enabled by a user variable.