### PR TITLE
increase token limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,8 @@ temperature=0.2
 generate a paragraph of lorem ipsum
 ```
 
-Below are listed all available configuration options, along with their default values:
+Below are listed all available configuration options, along with their default values.
+Please note that there isn't any token limit imposed, though 1000 is recommended.
 
 ```vim
 " :AI
@@ -271,7 +272,7 @@ let g:vim_ai_complete = {
 \  "options": {
 \    "model": "gpt-3.5-turbo-instruct",
 \    "endpoint_url": "https://api.openai.com/v1/completions",
-\    "max_tokens": 1000,
+\    "max_tokens": 0,
 \    "temperature": 0.1,
 \    "request_timeout": 20,
 \    "enable_auth": 1,
@@ -294,7 +295,7 @@ let g:vim_ai_edit = {
 \  "options": {
 \    "model": "gpt-3.5-turbo-instruct",
 \    "endpoint_url": "https://api.openai.com/v1/completions",
-\    "max_tokens": 1000,
+\    "max_tokens": 0,
 \    "temperature": 0.1,
 \    "request_timeout": 20,
 \    "enable_auth": 1,
@@ -327,7 +328,7 @@ let g:vim_ai_chat = {
 \  "options": {
 \    "model": "gpt-3.5-turbo",
 \    "endpoint_url": "https://api.openai.com/v1/chat/completions",
-\    "max_tokens": 1000,
+\    "max_tokens": 0,
 \    "temperature": 1,
 \    "request_timeout": 20,
 \    "enable_auth": 1,
@@ -392,7 +393,7 @@ let chat_engine_config = {
 \  "options": {
 \    "model": "gpt-3.5-turbo",
 \    "endpoint_url": "https://api.openai.com/v1/chat/completions",
-\    "max_tokens": 1000,
+\    "max_tokens": 0,
 \    "temperature": 0.1,
 \    "request_timeout": 20,
 \    "selection_boundary": "",

--- a/autoload/vim_ai_config.vim
+++ b/autoload/vim_ai_config.vim
@@ -5,7 +5,7 @@ let g:vim_ai_complete_default = {
 \  "options": {
 \    "model": "gpt-3.5-turbo-instruct",
 \    "endpoint_url": "https://api.openai.com/v1/completions",
-\    "max_tokens": 1000,
+\    "max_tokens": 0,
 \    "temperature": 0.1,
 \    "request_timeout": 20,
 \    "enable_auth": 1,
@@ -20,7 +20,7 @@ let g:vim_ai_edit_default = {
 \  "options": {
 \    "model": "gpt-3.5-turbo-instruct",
 \    "endpoint_url": "https://api.openai.com/v1/completions",
-\    "max_tokens": 1000,
+\    "max_tokens": 0,
 \    "temperature": 0.1,
 \    "request_timeout": 20,
 \    "enable_auth": 1,
@@ -41,7 +41,7 @@ let g:vim_ai_chat_default = {
 \  "options": {
 \    "model": "gpt-3.5-turbo",
 \    "endpoint_url": "https://api.openai.com/v1/chat/completions",
-\    "max_tokens": 1000,
+\    "max_tokens": 0,
 \    "temperature": 1,
 \    "request_timeout": 20,
 \    "enable_auth": 1,

--- a/doc/vim-ai.txt
+++ b/doc/vim-ai.txt
@@ -26,7 +26,7 @@ Options: >
   \  "options": {
   \    "model": "gpt-3.5-turbo-instruct",
   \    "endpoint_url": "https://api.openai.com/v1/completions",
-  \    "max_tokens": 1000,
+  \    "max_tokens": 0,
   \    "temperature": 0.1,
   \    "request_timeout": 20,
   \    "enable_auth": 1,
@@ -52,7 +52,7 @@ Options: >
   \  "options": {
   \    "model": "gpt-3.5-turbo-instruct",
   \    "endpoint_url": "https://api.openai.com/v1/completions",
-  \    "max_tokens": 1000,
+  \    "max_tokens": 0,
   \    "temperature": 0.1,
   \    "request_timeout": 20,
   \    "enable_auth": 1,
@@ -73,7 +73,6 @@ https://platform.openai.com/docs/api-reference/completions
                                     the instruction or both
 
 Options: >
-
   let s:initial_chat_prompt =<< trim END
   >>> system
 
@@ -84,7 +83,7 @@ Options: >
   let g:vim_ai_chat = {
   \  "options": {
   \    "model": "gpt-3.5-turbo",
-  \    "max_tokens": 1000,
+  \    "max_tokens": 0,
   \    "endpoint_url": "https://api.openai.com/v1/chat/completions",
   \    "temperature": 1,
   \    "request_timeout": 20,


### PR DESCRIPTION
I found the token limit rather arbitrary and surprising, as it is mentioned in passing in the configuration. If there's a reason why it ought to be 1000, then maybe document it, otherwise allow for messages with 1001 and more tokens. Since it can take users by surprise (until they realize that the token limit setting is the reason for the cutoffs), this commit removes it, but keeps 1000 as a recommendation