### PR TITLE
Fix print_info_message <Esc> issue

### DIFF
--- a/py/utils.py
+++ b/py/utils.py
@@ -231,7 +231,7 @@ def openai_request(url, data, options):
 
 def print_info_message(msg):
     vim.command("redraw")
-    vim.command("normal \\<Esc>")
+    vim.command('call feedkeys("\<Esc>")')
     vim.command("echohl ErrorMsg")
     vim.command(f"echomsg '{msg}'")
     vim.command("echohl None")


### PR DESCRIPTION
I ran into an issue when first using this plugin where the print_info_message function wasn't working correctly due to vim misinterpreting the `<Esc>` sequence in `vim.command("normal \\<Esc>")` as a series of individual characters rather than a single literal Escape character. This resulted in the characters 'c>' being inserted into the active buffer at the cursor location because the 's' in '`<Esc>`' was being interpreted as a normal mode 's', causing it to enter insert mode, and none of the info messages were being echoed properly. This was frustrating as it was not easy to figure out why my commands weren't working initially (turns out I hadn't configured my billing plan correctly, d'oh).

Fix this by using a more robust way of sending the `<Esc>` character to vim via `vim.command('call feedkeys("\<Esc>")')`.

The usage of double quotes inside the feedkeys() call is important because it causes vim to treat the sequence as a proper escape sequence rather than a series of individual characters (see :h feedkeys).