### PR TITLE
fix: grok xai blocks without user agent

### DIFF
--- a/py/utils.py
+++ b/py/utils.py
@@ -214,6 +214,7 @@ def openai_request(url, data, options):
     enable_auth=options['enable_auth']
     headers = {
         "Content-Type": "application/json",
+        "User-Agent": "VimAI",
     }
     if enable_auth:
         (OPENAI_API_KEY, OPENAI_ORG_ID) = load_api_key(options['token_file_path'])


### PR DESCRIPTION
When using Grok https://api.x.ai/v1/chat/completions endpoint, I was getting a 403.  

This was related to the `User-Agent` not being set.  Curl automatically sets the User-Agent to `curl/8.x`.

This change sets the User-Agent to `VimAI` which fixes the issue.