### PR TITLE
Fix empty space on assistant responses line when 'virtualedit=all' is set.

### DIFF
--- a/autoload/vim_ai.vim
+++ b/autoload/vim_ai.vim
@@ -187,7 +187,7 @@ function! vim_ai#AIEditRun(uses_range, config, ...) range abort
   \  "user_instruction": l:instruction,
   \  "user_selection": l:selection,
   \  "is_selection": l:is_selection,
-  \  "command_type": 'complete',
+  \  "command_type": 'edit',
   \}
   let l:context = py3eval("make_ai_context(unwrap('l:config_input'))")
   let l:config = l:context['config']

--- a/py/chat.py
+++ b/py/chat.py
@@ -78,7 +78,7 @@ def run_ai_chat(context):
                         yield chunk['content']
 
             chunks = make_chat_text_chunks(messages, options)
-            render_text_chunks(_chunks_to_sections(chunks))
+            render_text_chunks(_chunks_to_sections(chunks), append_to_eol=True)
 
             vim.command("normal! a\n\n>>> user\n\n")
             vim.command("redraw")

--- a/py/complete.py
+++ b/py/complete.py
@@ -4,6 +4,7 @@ complete_py_imported = True
 
 def run_ai_completition(context):
     prompt = context['prompt']
+    command_type = context['command_type']
     config = make_config(context['config'])
     config_options = config['options']
     config_ui = config['ui']
@@ -46,7 +47,7 @@ def run_ai_completition(context):
             print('Completing...')
             vim.command("redraw")
             text_chunks = engines[engine](prompt)
-            render_text_chunks(text_chunks)
+            render_text_chunks(text_chunks, append_to_eol=command_type == 'complete')
             clear_echo_message()
     except BaseException as error:
         handle_completion_error(error)

--- a/py/context.py
+++ b/py/context.py
@@ -153,6 +153,7 @@ def make_ai_context(params):
     prompt = make_prompt(config_prompt, user_prompt, user_selection, selection_boundary)
 
     return {
+        'command_type': command_type,
         'config': final_config,
         'prompt': prompt,
     }

--- a/py/utils.py
+++ b/py/utils.py
@@ -89,7 +89,7 @@ def need_insert_before_cursor():
         raise ValueError("Unexpected getpos value, it should be a list with two elements")
     return pos[1] == "1" # determines if visual selection starts on the first window column
 
-def render_text_chunks(chunks):
+def render_text_chunks(chunks, append_to_eol=False):
     generating_text = False
     full_text = ''
     insert_before_cursor = need_insert_before_cursor()
@@ -102,6 +102,8 @@ def render_text_chunks(chunks):
         if insert_before_cursor:
             vim.command("normal! i" + text)
             insert_before_cursor = False
+        elif append_to_eol: # for cases when virtualedit=all is set, to avoid empty space
+            vim.command("normal! A" + text)
         else:
             vim.command("normal! a" + text)
         vim.command("undojoin")


### PR DESCRIPTION
This make copying easier.

Before this change the AI would respond like this:
```
>>> assistant

 Hi
```

Now it responds like this:
```
>>> assistant

Hi
```