### PR TITLE
Show reasoner model's thinking in a `<<< thinking` section

### DIFF
--- a/py/chat.py
+++ b/py/chat.py
@@ -62,22 +62,23 @@ def run_ai_chat(context):
 
             print('Answering...')
 
-            first_thinking_chunk = True
-            first_content_chunk = True
+            def _chunks_to_sections(chunks):
+                first_thinking_chunk = True
+                first_content_chunk = True
+                for chunk in chunks:
+                    if chunk['thinking'] is not None:
+                        if first_thinking_chunk:
+                            first_thinking_chunk = False
+                            vim.command("normal! Go\n<<< thinking\n\n")
+                        yield chunk['thinking']
+                    if chunk['content'] is not None:
+                        if first_content_chunk:
+                            first_content_chunk = False
+                            vim.command("normal! Go\n<<< assistant\n\n")
+                        yield chunk['content']
 
-            text_chunks = make_chat_text_chunks(messages, options)
-            for chunk in text_chunks:
-                if text := chunk.get("thinking"):
-                    if first_thinking_chunk:
-                        first_thinking_chunk = False
-                        vim.command("normal! Go\n<<< thinking\n\n")
-                    vim.command("normal! A" + text)
-                if text := chunk.get("content"):
-                    if first_content_chunk:
-                        first_content_chunk = False
-                        vim.command("normal! Go\n<<< assistant\n\n")
-                    vim.command("normal! A" + text)
-                vim.command("redraw")
+            chunks = make_chat_text_chunks(messages, options)
+            render_text_chunks(_chunks_to_sections(chunks))
 
             vim.command("normal! a\n\n>>> user\n\n")
             vim.command("redraw")

--- a/py/complete.py
+++ b/py/complete.py
@@ -34,7 +34,10 @@ def run_ai_completition(context):
         chat_content = f"{initial_prompt}\n\n>>> user\n\n{prompt}".strip()
         messages = parse_chat_messages(chat_content)
         print_debug("[engine-chat] text:\n" + chat_content)
-        return make_chat_text_chunks(messages, config_options)
+        return filter(
+            lambda c: c,
+            map(lambda c: c.get("content"), make_chat_text_chunks(messages, config_options)),
+        )
 
     engines = {"chat": chat_engine, "complete": complete_engine}
 

--- a/py/utils.py
+++ b/py/utils.py
@@ -156,10 +156,12 @@ def parse_chat_messages(chat_content):
     for line in lines:
         match line:
             case '>>> system':
-                messages.append({'role': 'system', 'content': [{ 'type': 'text', 'text': '' }]})
+                messages.append({'role': 'system', 'content': ''})
                 current_type = 'system'
+            case '<<< thinking':
+                current_type = 'thinking'
             case '<<< assistant':
-                messages.append({'role': 'assistant', 'content': [{ 'type': 'text', 'text': '' }]})
+                messages.append({'role': 'assistant', 'content': ''})
                 current_type = 'assistant'
             case '>>> user':
                 if messages and messages[-1]['role'] == 'user':
@@ -175,7 +177,9 @@ def parse_chat_messages(chat_content):
                 if not messages:
                     continue
                 match current_type:
-                    case 'assistant' | 'system' | 'user':
+                    case 'system' | 'assistant':
+                        messages[-1]['content'] += '\n' + line
+                    case 'user':
                         messages[-1]['content'][-1]['text'] += '\n' + line
                     case 'include':
                         paths = parse_include_paths(line)
@@ -185,6 +189,10 @@ def parse_chat_messages(chat_content):
 
     for message in messages:
         # strip newlines from the text content as it causes empty responses
+
+        if isinstance(message['content'], str):
+            message['content'] = message['content'].strip()
+            continue
         for content in message['content']:
             if content['type'] == 'text':
                 content['text'] = content['text'].strip()
@@ -334,11 +342,19 @@ def make_chat_text_chunks(messages, config_options):
 
     def map_chunk_no_stream(resp):
         print_debug("[engine-chat] response: {}", resp)
-        return _choices(resp)[0].get('message', {}).get('content', '')
+        message = _choices(resp)[0].get('message', {})
+        reasoning_content = message.get('reasoning_content', '')
+        content = message.get('content', '')
+        return {"content": content, "thinking": reasoning_content}
 
     def map_chunk_stream(resp):
         print_debug("[engine-chat] response: {}", resp)
-        return _choices(resp)[0].get('delta', {}).get('content', '')
+        delta = _choices(resp)[0].get('delta', {})
+        if reasoning_content := delta.get('reasoning_content'):
+            return {"thinking": reasoning_content}
+        if content := delta.get('content'):
+            return {"content": content}
+        return {"content": ""}
 
     map_chunk = map_chunk_stream if openai_options['stream'] else map_chunk_no_stream
 

--- a/syntax/aichat.vim
+++ b/syntax/aichat.vim
@@ -1,6 +1,7 @@
 syntax match aichatRole ">>> system"
 syntax match aichatRole ">>> user"
 syntax match aichatRole ">>> include"
+syntax match aichatRole "<<< thinking"
 syntax match aichatRole "<<< assistant"
 
 highlight default link aichatRole Comment


### PR DESCRIPTION
Parse `reasoning_content` in response chunks and put it in a separate `<<< thinking` section. Do not send the contents of this section back to the model.

Tested with deepseek api and their `deepseek-reasoner` model.

Also tested locally with `sglang --model-path Qwen/QwQ-32B-AWQ --reasoning-parser deepseek-r1`:
```
>>> user

hi

<<< thinking

Okay, the user said "hi". I should respond in a friendly way. Maybe say "Hello! How can I assist you today?" That's a common greeting and opens the conversation for them to ask something. I need to keep it simple and welcoming. Let me check if there's anything else I should consider. No, that should be good. Alright, I'll go with that.


<<< assistant



Hello! How can I assist you today?

>>> user
```