### PR TITLE
1-line headers change to support Azure AI Foundry

### DIFF
--- a/py/utils.py
+++ b/py/utils.py
@@ -240,6 +240,7 @@ def openai_request(url, data, options):
     if enable_auth:
         (OPENAI_API_KEY, OPENAI_ORG_ID) = load_api_key(options['token_file_path'])
         headers['Authorization'] = f"Bearer {OPENAI_API_KEY}"
+        headers['api-key'] = f"{OPENAI_API_KEY}"
 
         if OPENAI_ORG_ID is not None:
             headers["OpenAI-Organization"] =  f"{OPENAI_ORG_ID}"


### PR DESCRIPTION
[Azure AI Foundry](https://ai.azure.com/) provides a simple interface to deploy LLMs, but the HTTP request headers are in a slightly different shape. 

Rather than an `Authorization` header containing the text `bearer: ` and the key, it is stored in an `api-key` header which is just the literal string of the api key with no additional text.

By adding that header, I have enjoyed this tool for several days. Thank you for your hard work! :bow: 