### PR TITLE
Try to send unmodified file paths from the `>>> include` section

### DIFF
--- a/tests/chat_test.py
+++ b/tests/chat_test.py
@@ -2,7 +2,9 @@ from utils import parse_chat_messages
 import os
 
 curr_dir = os.path.dirname(__file__)
-relative_dir = 'tests'
+relative_dir = os.path.relpath(curr_dir)
+home_dir = os.path.expanduser('~')
+abs_dir_private_home = curr_dir.replace(home_dir, '~', 1)
 
 def strip_text(txt):
     txt = txt.strip()
@@ -144,7 +146,7 @@ def test_parse_include_single_file_message():
 
     >>> include
 
-    {curr_dir}/resources/test1.include.txt
+    {relative_dir}/resources/test1.include.txt
 
     <<< assistant
 
@@ -154,7 +156,6 @@ def test_parse_include_single_file_message():
 
     try harder
     """)
-    messages = parse_chat_messages(chat_content)
     actual_messages = parse_chat_messages(chat_content)
     assert [
         {
@@ -199,9 +200,8 @@ def test_parse_include_multiple_files_message():
     >>> include
 
     {curr_dir}/resources/test1.include.txt
-    {curr_dir}/resources/test2.include.txt
+    {relative_dir}/resources/test2.include.txt
     """)
-    messages = parse_chat_messages(chat_content)
     actual_messages = parse_chat_messages(chat_content)
     assert [
         {
@@ -213,7 +213,7 @@ def test_parse_include_multiple_files_message():
                 },
                 {
                     'type': 'text',
-                    'text': f'==> {relative_dir}/resources/test1.include.txt <==\nhello world',
+                    'text': f'==> {abs_dir_private_home}/resources/test1.include.txt <==\nhello world',
                 },
                 {
                     'type': 'text',
@@ -244,11 +244,11 @@ def test_parse_include_glob_files_message():
                 },
                 {
                     'type': 'text',
-                    'text': f'==> {relative_dir}/resources/test1.include.txt <==\nhello world',
+                    'text': f'==> {abs_dir_private_home}/resources/test1.include.txt <==\nhello world',
                 },
                 {
                     'type': 'text',
-                    'text': f'==> {relative_dir}/resources/test2.include.txt <==\nvim is awesome',
+                    'text': f'==> {abs_dir_private_home}/resources/test2.include.txt <==\nvim is awesome',
                 },
             ],
         },
@@ -289,7 +289,7 @@ def test_parse_include_image_with_files_message():
 
     {curr_dir}/resources/test1.include.txt
     {curr_dir}/resources/image_file.jpg
-    {curr_dir}/resources/test2.include.txt
+    {relative_dir}/resources/test2.include.txt
     """)
     actual_messages = parse_chat_messages(chat_content)
     assert [
@@ -298,7 +298,7 @@ def test_parse_include_image_with_files_message():
             'content': [
                 {
                     'type': 'text',
-                    'text': f'==> {relative_dir}/resources/test1.include.txt <==\nhello world',
+                    'text': f'==> {abs_dir_private_home}/resources/test1.include.txt <==\nhello world',
                 },
                 {
                     'type': 'image_url',
@@ -328,11 +328,11 @@ def test_parse_include_unsupported_binary_file():
             'content': [
                 {
                     'type': 'text',
-                    'text': f'==> {relative_dir}/resources/binary_file.bin <==\nBinary file, cannot display',
+                    'text': f'==> {abs_dir_private_home}/resources/binary_file.bin <==\nBinary file, cannot display',
                 },
                 {
                     'type': 'text',
-                    'text': f'==> {relative_dir}/resources/test1.include.txt <==\nhello world',
+                    'text': f'==> {abs_dir_private_home}/resources/test1.include.txt <==\nhello world',
                 },
             ],
         },


### PR DESCRIPTION
When sending file paths from the `>>> include` section, try to send file paths as the user typed them instead of expanding them:
* When the user provides an absolute path, send it as-is, but replace home dir with `~` to avoid sending the username to API providers.
* When the user provides a relative path, send it as a relative path.
* When the user provides a glob under a relative path, keep the resulting path relative to the current working dir.

This is an attempt to improve https://github.com/madox2/vim-ai/pull/149 based on comments here https://github.com/madox2/vim-ai/commit/e375e05a2672ff70094cefe305ef9d13f60d62e7#commitcomment-153576019