### PR TITLE
feat: support field name `reasoning` in openrouter response

### DIFF
--- a/py/providers/openai.py
+++ b/py/providers/openai.py
@@ -61,6 +61,9 @@ class OpenAIProvider():
             if delta.get('reasoning_content'):
                 # NOTE: support for deepseek's reasoning_content
                 return {'type': 'thinking', 'content': delta.get('reasoning_content')}
+            if delta.get('reasoning'):
+                # NOTE: support for `reasoning` from openrouter
+                return {'type': 'thinking', 'content': delta.get('reasoning')}
             if delta.get('content'):
                 return {'type': 'assistant', 'content': delta.get('content')}
             return None # invalid chunk, this occured in deepseek models


### PR DESCRIPTION
as in the official doc: https://openrouter.ai/docs/use-cases/reasoning-tokens
> Reasoning tokens will appear in the reasoning field of each message, unless you decide to exclude them.