### PR TITLE
Add in optional web_search_options to be passed onto open_AI

### DIFF
--- a/py/providers/openai.py
+++ b/py/providers/openai.py
@@ -114,8 +114,8 @@ class OpenAIProvider():
         if options['temperature'] > -1:
             result['temperature'] = options['temperature']
 
-        if ['user_location'] in options:
-            result['user_location'] = options['user_location']
+        if ['web_search_options'] in options:
+            result['web_search_options'] = options['web_search_options']
 
         if max_tokens > 0:
             result['max_tokens'] = max_tokens

--- a/py/providers/openai.py
+++ b/py/providers/openai.py
@@ -114,6 +114,9 @@ class OpenAIProvider():
         if options['temperature'] > -1:
             result['temperature'] = options['temperature']
 
+        if ['user_location'] in options:
+            result['user_location'] = options['user_location']
+
         if max_tokens > 0:
             result['max_tokens'] = max_tokens
         if max_completion_tokens > 0:

--- a/py/providers/openai.py
+++ b/py/providers/openai.py
@@ -114,7 +114,7 @@ class OpenAIProvider():
         if options['temperature'] > -1:
             result['temperature'] = options['temperature']
 
-        if ['web_search_options'] in options:
+        if 'web_search_options' in options:
             result['web_search_options'] = options['web_search_options']
 
         if max_tokens > 0:

--- a/py/providers/openai.py
+++ b/py/providers/openai.py
@@ -25,9 +25,7 @@ class OpenAIProvider():
 
     def request(self, messages: Sequence[AIMessage]) -> Iterator[AIResponseChunk]:
         options = self.options
-        print(options)
         openai_options = self._make_openai_options(options)
-        print(openai_options)
         http_options = {
             'request_timeout': options['request_timeout'],
             'auth_type': options['auth_type'],

--- a/py/providers/openai.py
+++ b/py/providers/openai.py
@@ -25,7 +25,9 @@ class OpenAIProvider():
 
     def request(self, messages: Sequence[AIMessage]) -> Iterator[AIResponseChunk]:
         options = self.options
+        print(options)
         openai_options = self._make_openai_options(options)
+        print(openai_options)
         http_options = {
             'request_timeout': options['request_timeout'],
             'auth_type': options['auth_type'],


### PR DESCRIPTION
Changes the OpenAIProvider class to read web_search_options when it is available in the chat config. 

This allows for the these option to be set when using the search_preview models that have recently been released on the chat_api.

Since they will only be sent when set, I didn't update the default configs or docs as it is a niche use case. I can go do this if it is wanted.