### PR TITLE
README.md :  Adding OpenAI Responses API Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ If you are interested in more tips or would like to level up your Vim with more 
 This is the list of 3rd party provider plugins allowing to use different AI providers.
 
 - [google provider](https://github.com/madox2/vim-ai-provider-google) - Google's Gemini models
+- [OpenAI Responses API Provider](https://github.com/kevincojean/vim-ai-provider-openai-responses) - OpenAI Responses API compatibility plug-in
 
 In case you are interested in developing one, have a look at reference [google provider](https://github.com/madox2/vim-ai-provider-google).
 Do not forget to open PR updating this list.


### PR DESCRIPTION
README.md :  Adding OpenAI Responses API Provider

The code for the provider is available at:  
https://github.com/kevincojean/vim-ai-provider-openai-responses