### PR TITLE
Correct :AIUtilOpenRoles to :AIUtilRolesOpen

### DIFF
--- a/doc/tags
+++ b/doc/tags
@@ -5,7 +5,7 @@
 :AIRedo	vim-ai.txt	/*:AIRedo*
 :AIUtilDebugOff	vim-ai.txt	/*:AIUtilDebugOff*
 :AIUtilDebugOn	vim-ai.txt	/*:AIUtilDebugOn*
-:AIUtilOpenRoles	vim-ai.txt	/*:AIUtilOpenRoles*
+:AIUtilRolesOpen	vim-ai.txt	/*:AIUtilRolesOpen*
 g:aichat_markdown	vim-ai.txt	/*g:aichat_markdown*
 vim-ai	vim-ai.txt	/*vim-ai*
 vim-ai-about	vim-ai.txt	/*vim-ai-about*

--- a/doc/vim-ai.txt
+++ b/doc/vim-ai.txt
@@ -189,9 +189,9 @@ https://platform.openai.com/docs/api-reference/images/create
 :AIRedo                             repeat last AI command in order to re-try
                                     or get an alternative completion.
 
-                                                *:AIUtilOpenRoles*
+                                                *:AIUtilRolesOpen*
 
-:AIUtilOpenRoles                    open role configuration file
+:AIUtilRolesOpen                    open role configuration file
 
                                                 *:AIUtilDebugOn*
 


### PR DESCRIPTION
This commit fixes an inaccuracy in the documentation by updating the command name from `:AIUtilOpenRoles` to the correct `:AIUtilRolesOpen`. This ensures the manual accurately reflects the actual command available.