### PR TITLE
Add filetype modeline setting for Vim help documentation

### DIFF
--- a/doc/vim-ai.txt
+++ b/doc/vim-ai.txt
@@ -350,3 +350,5 @@ ABOUT                                           *vim-ai-about*
 Contributions are welcome on GitHub:
 
 https://github.com/madox2/vim-ai
+
+vim:filetype=help


### PR DESCRIPTION
enables help doc syntax.

doc syntax is currently breaking in nvim because the filetype is being interpreted as `text`